### PR TITLE
pointing to the right file for bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,7 @@
 {
   "name": "modernizr",
   "version": "2.8.3",
+  "main": "modernizr.js",
   "description": "Modernizr is a JavaScript library that detects HTML5 and CSS3 features in the user's browser.",
   "homepage": "http://modernizr.com/",
   "keywords": [


### PR DESCRIPTION
Currently it's hard to use moderinzr as a bower dependency, because it doesn't point to the right file.
This change will solve this problem.