### PR TITLE
Add license to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,5 +13,6 @@
   "author": "Modernizr <http://modernizr.com>",
   "main": [
     "modernizr.js"
-  ]
+  ],
+  "license": "MIT"
 }


### PR DESCRIPTION
This is required by that webjars such that it can pick up this bower package automatically.
